### PR TITLE
Fix Hotkey related discrepancy.

### DIFF
--- a/docs/hotkeys.mdx
+++ b/docs/hotkeys.mdx
@@ -60,7 +60,7 @@ This hotkey emulates a press of the <Hotkey buttons={["A2"]}/> button as not all
 
 This hotkey changes the SOCD cleaning method to resolve to a neutral input (no input) on the X-axis, but prioritize the `Up` input on the Y-axis when both directions are pressed simultaneously.
 
-**Default**: <Hotkey buttons={["S1", "A1", "Up"]}/>
+**Default**: <Hotkey buttons={["S2", "A1", "Up"]}/>
 
 | 1st Input + 2nd Input | Result  |
 | :-------------------: | :-----: |
@@ -73,7 +73,7 @@ This hotkey changes the SOCD cleaning method to resolve to a neutral input (no i
 
 This hotkey changes the SOCD cleaning method to resolve to a neutral input (no input) on both the X-axis and Y-axis when both directions are pressed simultaneously.
 
-**Default**: <Hotkey buttons={["S1", "A1", "Down"]}/>
+**Default**: <Hotkey buttons={["S2", "A1", "Down"]}/>
 
 | 1st Input + 2nd Input | Result  |
 | :-------------------: | :-----: |
@@ -86,7 +86,7 @@ This hotkey changes the SOCD cleaning method to resolve to a neutral input (no i
 
 This hotkey changes the SOCD cleaning method to prioritize the second directional input on both the X-axis and Y-axis when both directions are pressed simultaneously.
 
-**Default**: <Hotkey buttons={["S1", "A1", "Left"]}/>
+**Default**: <Hotkey buttons={["S2", "A1", "Left"]}/>
 
 | 1st Input + 2nd Input | Result |
 | :-------------------: | :----: |
@@ -130,8 +130,6 @@ This hotkey will invert the X-axis of your controller (i.e. pressing the Right b
 ## Invert Y Axis
 
 This hotkey will invert the Y-axis of your controller (i.e. pressing the Up button will result in a Down input and vice versa).
-
-**Default**: <Hotkey buttons={["S2", "A1", "Right"]}/>
 
 ## Toggle 4-Way Joystick Mode
 

--- a/docs/usage.mdx
+++ b/docs/usage.mdx
@@ -87,11 +87,10 @@ A number of hotkeys are enabled by default and if you are encountering issues wi
 | [Home Button](hotkeys.mdx#home-button)             | <Hotkey buttons={["S1","S2","Up"]}/>    |
 | [Dpad Digital](hotkeys.mdx#dpad-digital)           | <Hotkey buttons={["S1","S2","Down"]}/>  |
 | [Dpad Left Analog](hotkeys.mdx#dpad-left-analog)   | <Hotkey buttons={["S1","S2","Left"]}/>  |
-| [Dpad Right Analog](hotkeys.mdx#dpad-right-analog) | <Hotkey buttons={["S2","A1","Right"]}/> |
+| [Dpad Right Analog](hotkeys.mdx#dpad-right-analog) | <Hotkey buttons={["S1","S2","Right"]}/> |
 | [SOCD Up Priority](hotkeys.mdx#socd-up-priority)   | <Hotkey buttons={["S2","A1","Up"]}/>    |
 | [SOCD Neutral](hotkeys.mdx#socd-neutral)           | <Hotkey buttons={["S2","A1","Down"]}/>  |
 | [SOCD Last Wins](hotkeys.mdx#socd-last-win)        | <Hotkey buttons={["S2","A1","Left"]}/>  |
-| [SOCD Invert Y Axis](hotkeys.mdx#invert-y-axis)    | <Hotkey buttons={["S2","A1","Right"]}/> |
 
 :::note
 


### PR DESCRIPTION
- Currently no default Hotkey set for Invert Y-Axis
- Hotkeys page SOCD Cleaning default shows S1+A1+Direction, when actual default is S2+A1
- Usage page Dpad Right Analog shows S2+A1+Right, when actual default is S1+S2+Right