### PR TITLE
Fix Environment setup for Windows Pico SDK instructions

### DIFF
--- a/docs/development/firmware-development.mdx
+++ b/docs/development/firmware-development.mdx
@@ -25,11 +25,12 @@ For GP2040-CE development on the Windows platform using the Pico SDK Installer, 
 <TabItem value="Windows (Pico SDK)" label="Windows (Pico SDK)" default>
 
 1. Download and install [CMake](https://github.com/Kitware/CMake/releases/download/v3.27.4/cmake-3.27.4-windows-x86_64.msi).
-2. Download and install [pico-setup-windows-x64-standalone](https://github.com/raspberrypi/pico-setup-windows/releases/).
-3. Download and install VSCode.
-4. Download and install [Windows Terminal](https://github.com/microsoft/terminal/releases/tag/v1.17.11461.0).
-5. Open Windows Terminal.
-6. Download the GP2040-CE-main repository by running the following commands in the Windows Terminal. This will download the folder to `C:\Users\user\GP2040-CE`.
+2. Install [NodeJS](https://nodejs.org/en/download) and NPM
+3. Download and install [pico-setup-windows-x64-standalone](https://github.com/raspberrypi/pico-setup-windows/releases/).
+4. Download and install VSCode.
+5. Download and install [Windows Terminal](https://github.com/microsoft/terminal/releases/tag/v1.17.11461.0).
+6. Open Windows Terminal.
+7. Download the GP2040-CE-main repository by running the following commands in the Windows Terminal. This will download the folder to `C:\Users\user\GP2040-CE`.
 
    ```console
    git clone https://github.com/OpenStickCommunity/GP2040-CE.git


### PR DESCRIPTION
Pico setup for windows does not include NodeJS/NPM and the build will fail.  Adding step to install NodeJS and NPM to the Windows (Pico SDK) environment setup instructions.