### PR TITLE
fix typo in tilt input add-on docs.

### DIFF
--- a/docs/add-ons/tilt-input.mdx
+++ b/docs/add-ons/tilt-input.mdx
@@ -18,13 +18,13 @@ Purpose: The Tilt Input add-on allows users to send analog inputs from the Left 
 - `Tilt 1 Pin` - The GPIO pin used for the Tilt 1 direction.
 - `Tilt 1 Factor Left X` - The percentage of the X-axis input for the Left analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
 - `Tilt 1 Factor Left Y` - The percentage of the Y-axis input for the Left analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
-- `Tilt 1 Factor Left X` - The percentage of the X-axis input for the Right analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
-- `Tilt 1 Factor Left Y` - The percentage of the Y-axis input for the Right analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
+- `Tilt 1 Factor Right X` - The percentage of the X-axis input for the Right analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
+- `Tilt 1 Factor Right Y` - The percentage of the Y-axis input for the Right analog joystick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
 - `Tilt 2 Pin` - The GPIO pin used for the Tilt 2 direction.
 - `Tilt 2 Factor Left X` - The percentage of the X-axis input for the Left analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
 - `Tilt 2 Factor Left Y` - The percentage of the Y-axis input for the Left analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
-- `Tilt 2 Factor Left X` - The percentage of the X-axis input for the Right analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
-- `Tilt 2 Factor Left Y` - The percentage of the Y-axis input for the Right analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
+- `Tilt 2 Factor Right X` - The percentage of the X-axis input for the Right analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
+- `Tilt 2 Factor Right Y` - The percentage of the Y-axis input for the Right analog joystick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
 - `Tilt Left Analog Up Pin` - The GPIO pin used for the Up direction on the Left analog joystick.
 - `Tilt Left Analog Down Pin` - The GPIO pin used for the Down direction on the Left analog joystick.
 - `Tilt Left Analog Left Pin` - The GPIO pin used for the Left direction on the Left analog joystick.


### PR DESCRIPTION
Tilt N Factor Left X/Y is repeated twice.