### PR TITLE
Include link to I2C Block table on Display Configuration page.

### DIFF
--- a/docs/web-configurator/menu-pages/07-display-configuration.mdx
+++ b/docs/web-configurator/menu-pages/07-display-configuration.mdx
@@ -16,7 +16,7 @@ GP2040-CE supports the use of a display module such as an OLED with a SSD1306, S
 ## Hardware Options
 
 - `Enabled` - Turns on/off the display module.
-- `I2C Block` - The Pico I2C block that will be used. Set based on pins, refer to table on page.
+- `I2C Block` - The Pico I2C block that will be used. Set based on pins, refer to table on the [Peripheral Mapping](https://gp2040-ce.info/web-configurator/menu-pages/peripheral-mapping#i2c) page.
 - `I2C Address` - The I2C address of your device, defaults to the very commonly used `0x3C`.
 
 ## Screen Options


### PR DESCRIPTION
The Display Configuration page says to refer to an I2C Block table, but it doesn't indicate where it is.