### PR TITLE
Fix contribution-guide typo

### DIFF
--- a/development/contribution-guide.mdx
+++ b/development/contribution-guide.mdx
@@ -26,7 +26,7 @@ Never made an open source contribution before? Wondering how contributions work 
 1. Sign up for a GitHub account.
 2. Find an issue you are interested in addressing, or a feature you would like to add.
 3. Fork the repository associated with the issue to your GitHub account. This means that you will have a copy of the repository under `your-GitHub-username/GP2040-CE`.
-4. Clone the repository to your local machine using `git clone https://github.com/OpenStickCommunity/GP2040-CE`
+4. Clone the repository to your local machine using `git clone https://github.com/your-GitHub-username/GP2040-CE`
 5. If you’re working on a new feature consider opening an issue to talk with us about the work you’re about to undertake.
 6. Create a new branch for your fix using `git checkout -b branch-name-here`.
 7. Make the appropriate changes for the issue you are trying to address or the feature that you want to add.


### PR DESCRIPTION
Step 4 currently lists the OpenStickCommunity repo URL in the example `clone` command. 
This PR updates that URL to match the example URL provided in Step 3 when creating a fork of the project.