### PR TITLE
Creates Development Environment Section in Contribute

### DIFF
--- a/development/contribution-guide.mdx
+++ b/development/contribution-guide.mdx
@@ -40,6 +40,10 @@ Never made an open source contribution before? Wondering how contributions work 
 15. Make changes to the pull request if the reviewing maintainer recommends them.
 16. Celebrate your success after your pull request is merged!
 
+## Development Environment
+
+You can find a detailed guide on how to set up a development environment for Windows or Linux [here](/development/build-environment). There are also guides available on how to [compile the firmware](/development/compile-firmware) and how to [debug](/development/debugging).
+
 ## Coding Conventions
 
 ## General Guidelines


### PR DESCRIPTION
The suggested change adds a section below the "How do I make a contribution?" section to make it easier to find the "Set Up Build Environment", "Compile Firmware", and "Debugging" pages when navigating documentation on a phone.