### PR TITLE
fix Display Configuration - Status Bar Layout - Profile description

### DIFF
--- a/docs/web-configurator/menu-pages/07-display-configuration.mdx
+++ b/docs/web-configurator/menu-pages/07-display-configuration.mdx
@@ -48,7 +48,7 @@ Be sure to pick left and right layouts that match. Some layout combinations resu
 - `D-Pad Mode` - Allows you to show or hide the `D-Pad Mode` on your display.
 - `SOCD Mode` - Allows you to show or hide the `SOCD Mode` on your display.
 - `Macro Mode` - Allows you to show or hide the `Macro Mode` on your display.
-- `Profile` - Allows you to show or hide the `Profile` pop-up on your display (if profiles are enabled).
+- `Profile` - Allows you to show or hide the `Profile` name on your display (if profiles are enabled).
 
 ## Input History Layout
 


### PR DESCRIPTION
![rendered](https://github.com/user-attachments/assets/5de1d4ea-671e-48c3-8362-4f74afb032a4)
The Profile toggle for the status bar controls whether the persistent `Pr: <profile>` text shows, the profile pop-up always appears regardless of the toggle setting