### PR TITLE
fix Touchpad references to be A2 not A1

### DIFF
--- a/docs/hotkeys.mdx
+++ b/docs/hotkeys.mdx
@@ -173,7 +173,7 @@ This hotkey emulates a press of the Touchpad button as not all controllers may h
 
 :::note
 
-The Touchpad Button is distinct from the [A1 Button](#a1-button) hotkey as this hotkey will trigger the Touchpad button regardless of whether the toggle for `Switch Touchpad and Share` is on or off.
+The Touchpad Button is distinct from the [A2 Button](#a2-button) hotkey as this hotkey will trigger the Touchpad button regardless of whether the toggle for `Switch Touchpad and Share` is on or off.
 
 :::
 
@@ -225,15 +225,15 @@ This hotkey emulates a press of the <Hotkey buttons={["S2"]}/> button as not all
 
 This hotkey emulates a press of the <Hotkey buttons={["A1"]}/> button as not all controllers may have this button natively on the controller.
 
-:::note
-
-The A1 Button hotkey is distinct from the [Touchpad Button](#touchpad-button) hotkey as this hotkey will trigger either the Touchpad button or Share button depending on whether the toggle for [`Switch Touchpad and Share`](./web-configurator/menu-pages/01-settings.mdx#additional-ps4-settings) is on or off.
-
-:::
-
 ## A2 Button
 
 This hotkey emulates a press of the <Hotkey buttons={["A2"]}/> button as not all controllers may have this button natively on the controller.
+
+:::note
+
+The A2 Button hotkey is distinct from the [Touchpad Button](#touchpad-button) hotkey as this hotkey will trigger either the Touchpad button or Share button depending on whether the toggle for [`Switch Touchpad and Share`](./web-configurator/menu-pages/01-settings.mdx#additional-ps4-settings) is on or off.
+
+:::
 
 ## Focus Mode Toggle
 


### PR DESCRIPTION
Touchpad should be `A2`, as per https://gp2040-ce.info/usage and https://gp2040-ce.info/web-configurator/menu-pages/settings/#additional-ps4-settings

Rendered:
<img width="1007" height="252" alt="image" src="https://github.com/user-attachments/assets/ad4d45a1-233e-4bdc-9c4f-1a3611d3fea0" />
<img width="1004" height="251" alt="image" src="https://github.com/user-attachments/assets/d1914d5d-6cc5-4270-aadc-b5ada398dbc5" />
